### PR TITLE
fix invalid multibyte escape bug

### DIFF
--- a/lib/quartz_torrent/trackerclient.rb
+++ b/lib/quartz_torrent/trackerclient.rb
@@ -29,7 +29,7 @@ module QuartzTorrent
   # Represents a peer returned by the tracker
   class TrackerPeer
     def initialize(ip, port, id = nil)
-      if ip =~ /(\d+).(\d+).(\d+).(\d+)/
+      if ip =~ /(\d+).(\d+).(\d+).(\d+)/n
         @ip = ip
         @port = port
         @id = id


### PR DESCRIPTION
this fixes quartz-torrent on later versions of ruby. right now, this is what happens trying to use under ruby 2.2.3:

```
irb(main):002:0> require 'quartz_torrent'
SyntaxError: /Users/igor47/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/quartz_torrent-0.2.0/lib/quartz_torrent/trackerclient.rb:32: invalid multibyte escape: /[\x80-\xff]/
	from /Users/igor47/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/quartz_torrent-0.2.0/lib/quartz_torrent/peerclient.rb:2:in `require'
	from /Users/igor47/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/quartz_torrent-0.2.0/lib/quartz_torrent/peerclient.rb:2:in `<top (required)>'
	from /Users/igor47/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/quartz_torrent-0.2.0/lib/quartz_torrent.rb:2:in `require'
	from /Users/igor47/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/quartz_torrent-0.2.0/lib/quartz_torrent.rb:2:in `<top (required)>'
	from (irb):2:in `require'
	from (irb):2
	from /Users/igor47/.rbenv/versions/2.2.3/bin/irb:11:in `<main>'
```

can you release an updated version? thanks!