### PR TITLE
Resolve 'invalid multibyte escape' in ruby >=2.0

### DIFF
--- a/lib/quartz_torrent/trackerclient.rb
+++ b/lib/quartz_torrent/trackerclient.rb
@@ -1,3 +1,4 @@
+# encoding: US-ASCII
 require "quartz_torrent/log"
 require "quartz_torrent/metainfo"
 require "quartz_torrent/udptrackermsg"


### PR DESCRIPTION
In v2.0 and up we need to add a decorator to bring back old behavior of multibyte escape parsing ([see here](https://techoverflow.net/2013/12/29/solving-invalid-multibyte-escape-xfexff-in-ruby-vpim/))